### PR TITLE
Fix: Missing Preview URL

### DIFF
--- a/app/api/spotify/route.ts
+++ b/app/api/spotify/route.ts
@@ -1,21 +1,25 @@
 import { NowPlaying, Providers } from "@bolajiolajide/now-playing";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
 export const GET = async () => {
   try {
-    if (process.env.NODE_ENV !== 'production') {
-      return new Response(JSON.stringify({
-        title: 'Test Song (Non-production env)',
-        artiste: 'Chronixx',
-        image_url: 'https://i.scdn.co/image/ab67616d0000b273fb3d081418a02919fb1bb58f',
-        is_playing: true,
-        preview_url: 'https://p.scdn.co/mp3-preview/2d7798a99d7c4091da509418b6b752463d569547?cid=98dee14da74049fdbc531633fec2f9ae',
-        url: ''
-      }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+    if (process.env.NODE_ENV !== "production") {
+      return new Response(
+        JSON.stringify({
+          title: "Test Song (Non-production env)",
+          artiste: "Chronixx",
+          image_url:
+            "https://i.scdn.co/image/ab67616d0000b273fb3d081418a02919fb1bb58f",
+          is_playing: true,
+          preview_url: null,
+          url: "https://open.spotify.com/track/0IFwcLA3vdeS9IxypgiQ8N",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
     }
 
     const nowPlaying = new NowPlaying(Providers.SPOTIFY, {

--- a/app/hero.tsx
+++ b/app/hero.tsx
@@ -9,7 +9,6 @@ import { useSpotify, type SpotifyPlayingDetails } from "./context/spotify";
 
 import Spinner from "./components/spinner";
 
-
 const Hero = () => {
   const playingDetails = useSpotify();
   const [playing, setPlaying] = useState(false);
@@ -63,7 +62,12 @@ const Hero = () => {
               onEnded={() => setPlaying(false)}
             />
           )}
-          <WhatsPlaying playingDetails={playingDetails} statusText={statusText} playing={playing} handlePlayPause={handlePlayPause} />
+          <WhatsPlaying
+            playingDetails={playingDetails}
+            statusText={statusText}
+            playing={playing}
+            handlePlayPause={handlePlayPause}
+          />
           <h1>
             Bolaji <br /> Olajide
           </h1>
@@ -124,16 +128,31 @@ interface WhatsPlayingProps {
   handlePlayPause: () => void;
 }
 
-const WhatsPlaying: FC<WhatsPlayingProps> = ({ playingDetails, statusText, playing, handlePlayPause }) => {
+const WhatsPlaying: FC<WhatsPlayingProps> = ({
+  playingDetails,
+  statusText,
+  playing,
+  handlePlayPause,
+}) => {
   if (playingDetails.loading) {
-    return <div className="hero__spinner"><Spinner /></div>;
+    return (
+      <div className="hero__spinner">
+        <Spinner />
+      </div>
+    );
   }
 
   return (
-    <button className="now-playing" onClick={() => handlePlayPause()}>
-      <span className="now-playing__status">
-        {playing ? <Playing /> : "🔇"}
-      </span>
+    <button
+      className="now-playing"
+      onClick={() => handlePlayPause()}
+      data-hover={playingDetails.previewUrl ? "true" : "false"}
+    >
+      {!!playingDetails.previewUrl && (
+        <span className="now-playing__status">
+          {playing ? <Playing /> : "🔇"}
+        </span>
+      )}
       {playingDetails.artistName && playingDetails.songName ? (
         <>
           <span className="sr-only">
@@ -169,9 +188,11 @@ const WhatsPlaying: FC<WhatsPlayingProps> = ({ playingDetails, statusText, playi
             </span>
           </span>
         </>
-      ) : <span>CURRENTLY OFFLINE.</span>}
+      ) : (
+        <span>CURRENTLY OFFLINE.</span>
+      )}
     </button>
-  )
-}
+  );
+};
 
 export default Hero;

--- a/styles/_elements.scss
+++ b/styles/_elements.scss
@@ -213,13 +213,18 @@
   max-width: min(400px, 90vw);
   align-items: center;
   position: relative;
-  cursor: pointer;
   gap: 6px;
 
-  &:hover {
-    background: transparent;
-    color: var(--foreground);
+  &[data-hover="true"] {
+    cursor: pointer;
 
+    &:hover {
+      background: transparent;
+      color: var(--foreground);
+    }
+  }
+
+  &:hover {
     .scroll-text {
       animation-play-state: paused;
     }
@@ -488,13 +493,14 @@
   height: 18px;
   position: relative;
 
-  &::before , &::after {
-    content: '';
+  &::before,
+  &::after {
+    content: "";
     position: absolute;
     left: 50%;
-    transform: translate(-50% , 10%);
+    transform: translate(-50%, 10%);
     top: 0;
-    background: #FF3D00;
+    background: #ff3d00;
     width: 16px;
     height: 16px;
     border-radius: 50%;
@@ -505,16 +511,24 @@
     background: #0000;
     color: #fff;
     top: 100%;
-    box-shadow: 32px -20px , -32px -20px;
+    box-shadow: 32px -20px, -32px -20px;
     animation: split 0.5s ease-out infinite alternate;
   }
 }
 
 @keyframes split {
-  0% { box-shadow: 8px -20px, -8px -20px}
-  100% { box-shadow: 32px -20px , -32px -20px}
+  0% {
+    box-shadow: 8px -20px, -8px -20px;
+  }
+  100% {
+    box-shadow: 32px -20px, -32px -20px;
+  }
 }
 @keyframes jump {
- 0% { transform: translate(-50% , -150%)}
- 100% { transform: translate(-50% , 10%)}
+  0% {
+    transform: translate(-50%, -150%);
+  }
+  100% {
+    transform: translate(-50%, 10%);
+  }
 }


### PR DESCRIPTION
### Description
- Just a workaround to remove the speaker icon when the preview url is null.

I am thinking that the data-hover attribute can be removed and we do something like `window.location.href` and redirect to the page of the song on Spotify.